### PR TITLE
Feat: 인증코드 관련 Api -> DB 방식, Redis 방식으로 분리 + Refresh Token 방식 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 HELP.md
 .gradle
+docker-compose.yml
+Dockerfile
 build/
 src/main/resources/application.yml
 src/main/resources-dev/application-dev.yml

--- a/build.gradle
+++ b/build.gradle
@@ -71,4 +71,5 @@ compileQuerydsl.doFirst {
 	if(file(querydslDir).exists())
 		delete(file(querydslDir))
 }
+tasks.withType(JavaCompile) { options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir) }
 //querydsl 추가 끝

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/advice/GlobalExceptionHandler.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/advice/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package GraduationWorkSalesProject.graduation.com.advice;
 
 import GraduationWorkSalesProject.graduation.com.dto.error.ErrorResponse;
 import GraduationWorkSalesProject.graduation.com.exception.*;
+import io.jsonwebtoken.SignatureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 import static GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @RestControllerAdvice("GraduationWorkSalesProject.graduation.com.controller")
 public class GlobalExceptionHandler {
@@ -66,9 +68,33 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> expiredRefreshTokenExceptionHandler(ExpiredRefreshTokenException e) {
+        final ErrorResponse response = ErrorResponse.of(EXPIRED_REFRESH_TOKEN);
+        return new ResponseEntity<>(response, UNAUTHORIZED);
+    }
+
+    @ExceptionHandler
     protected ResponseEntity<ErrorResponse> expiredCertificationCodeExceptionHandler(ExpiredCertificationCodeException e) {
         final ErrorResponse response = ErrorResponse.of(EXPIRED_CERTIFICATION_CODE);
         return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> refreshTokenNotMatchExceptionHandler(RefreshTokenNotMatchException e) {
+        final ErrorResponse response = ErrorResponse.of(REFRESH_TOKEN_NOT_MATCH);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> signatureExceptionHandler(SignatureException e) {
+        final ErrorResponse response = ErrorResponse.of(SIGNATURE_NOT_MATCH);
+        return new ResponseEntity<>(response, BAD_REQUEST);
+    }
+
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> invalidJwtExceptionHandler(InvalidJwtException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_TOKEN);
+        return new ResponseEntity<>(response, UNAUTHORIZED);
     }
 
     @ExceptionHandler

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtAuthenticationEntryPoint.java
@@ -21,11 +21,12 @@ public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
     //  https://sas-study.tistory.com/362 참고
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        ErrorCode errorCode = (ErrorCode) request.getAttribute("errorCode");
+        response.setStatus(errorCode.getStatus());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         try (OutputStream os = response.getOutputStream()){
             ObjectMapper objectMapper = new ObjectMapper();
-            objectMapper.writeValue(os, ErrorResponse.of(ErrorCode.UNAUTHORIZED));
+            objectMapper.writeValue(os, ErrorResponse.of(errorCode));
             os.flush();
         }
     }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtRequestFilter.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtRequestFilter.java
@@ -1,7 +1,10 @@
 package GraduationWorkSalesProject.graduation.com.config;
 
+import GraduationWorkSalesProject.graduation.com.exception.InvalidAuthorizationHeaderException;
 import GraduationWorkSalesProject.graduation.com.service.JwtUserDetailsService;
+import GraduationWorkSalesProject.graduation.com.service.MemberService;
 import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,6 +20,8 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
+import static GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode.*;
+
 @Component
 @RequiredArgsConstructor
 @Slf4j
@@ -24,6 +29,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
 
     private final JwtUserDetailsService jwtUserDetailsService;
     private final JwtTokenUtil jwtTokenUtil;
+    private final MemberService memberService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
@@ -32,30 +38,30 @@ public class JwtRequestFilter extends OncePerRequestFilter {
         String requestTokenHeader = request.getHeader("Authorization");
         log.debug("[Token] {}", requestTokenHeader);
 
-        if (requestTokenHeader != null && requestTokenHeader.startsWith("Bearer ")) {
+        try {
+            if (requestTokenHeader == null || !requestTokenHeader.startsWith("Bearer ")) {
+                throw new InvalidAuthorizationHeaderException();
+            }
             jwtToken = requestTokenHeader.substring(7);
-            try {
-                username = jwtTokenUtil.getUsernameFromToken(jwtToken);
-            } catch (IllegalArgumentException e) {
-                log.warn("Unable to get JWT Token");
-            } catch (ExpiredJwtException e) {
-                log.warn("JWT Token has expired");
+            username = jwtTokenUtil.getUsernameFromAccessToken(jwtToken);
+
+            if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
+
+                if (jwtTokenUtil.validateAccessToken(jwtToken)) {
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                    usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
             }
-        } else {
-            log.warn("JWT Token does not begin with Bearer String");
-        }
-
-        if (username != null && SecurityContextHolder.getContext().getAuthentication() == null) {
-            UserDetails userDetails = this.jwtUserDetailsService.loadUserByUsername(username);
-
-            if (jwtTokenUtil.validateToken(jwtToken, userDetails)) {
-                UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
-                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-                usernamePasswordAuthenticationToken
-                        .setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-
-                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
-            }
+        } catch (InvalidAuthorizationHeaderException e) {
+            request.setAttribute("errorCode", INVALID_AUTHORIZATION_HEADER);
+        } catch (ExpiredJwtException e) {
+            log.warn("JWT Access Token has expired");
+            request.setAttribute("errorCode", EXPIRED_ACCESS_TOKEN);
+        } catch (JwtException e) {
+            log.warn("Unable to get JWT Token");
+            request.setAttribute("errorCode", INVALID_TOKEN);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
@@ -1,8 +1,8 @@
 package GraduationWorkSalesProject.graduation.com.config;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import GraduationWorkSalesProject.graduation.com.exception.InvalidJwtException;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
@@ -12,53 +12,103 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
+@Slf4j
 @Component
 public class JwtTokenUtil {
 
-    public static final long JWT_TOKEN_VALIDITY = 30 * 60 * 1000;
+    @Value("${jwt.access.validity}")
+    private long ACCESS_TOKEN_VALIDITY;
+    @Value("${jwt.refresh.validity}")
+    private long REFRESH_TOKEN_VALIDITY;
 
-    @Value("${jwt.secret}")
-    private String secret;
+    @Value("${jwt.access.secret}")
+    private String ACCESS_TOKEN_SECRET;
+    @Value("${jwt.refresh.secret}")
+    private String REFRESH_TOKEN_SECRET;
 
-    public String getUsernameFromToken(String token) {
-        return getClaimFromToken(token, Claims::getSubject);
+    public String getUsernameFromAccessToken(String token) {
+        return getClaimFromAccessToken(token, Claims::getSubject);
     }
 
-    public Date getExpirationDateFromToken(String token) {
-        return getClaimFromToken(token, Claims::getExpiration);
+    public String getUsernameFromRefreshToken(String token) {
+        return getClaimFromRefreshToken(token, Claims::getSubject);
     }
 
-    public <T> T getClaimFromToken(String token, Function<Claims, T> claimsResolver) {
-        Claims claims = getAllClaimsFromToken(token);
+    public Date getExpirationDateFromAccessToken(String token) {
+        return getClaimFromAccessToken(token, Claims::getExpiration);
+    }
+
+    public Date getExpirationDateFromRefreshToken(String token) {
+        return getClaimFromRefreshToken(token, Claims::getExpiration);
+    }
+
+    public <T> T getClaimFromAccessToken(String token, Function<Claims, T> claimsResolver) {
+        Claims claims = getAllClaimsFromAccessToken(token);
         return claimsResolver.apply(claims);
     }
 
-    private Claims getAllClaimsFromToken(String token) {
-        return Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+    public <T> T getClaimFromRefreshToken(String token, Function<Claims, T> claimsResolver) {
+        Claims claims = getAllClaimsFromRefreshToken(token);
+        return claimsResolver.apply(claims);
     }
 
-    private Boolean isTokenExpired(String token) {
-        Date expiration = getExpirationDateFromToken(token);
-        return expiration.before(new Date());
+    private Claims getAllClaimsFromAccessToken(String token) {
+        return Jwts.parser().setSigningKey(ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody();
     }
 
-    public String generateToken(UserDetails userDetails) {
+    private Claims getAllClaimsFromRefreshToken(String token) {
+        try {
+            Claims body = Jwts.parser().setSigningKey(REFRESH_TOKEN_SECRET).parseClaimsJws(token).getBody();
+            System.out.println("body = " + body.getSubject());
+        } catch (Exception e) {
+            e.getStackTrace();
+        }
+        return Jwts.parser().setSigningKey(REFRESH_TOKEN_SECRET).parseClaimsJws(token).getBody();
+    }
+
+    public String generateAccessToken(UserDetails userDetails) {
         Map<String, Object> claims = new HashMap<>();
-        return doGenerateToken(claims, userDetails.getUsername());
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "AccessToken");
+        return doGenerateToken(claims, headers, userDetails.getUsername(), ACCESS_TOKEN_VALIDITY, ACCESS_TOKEN_SECRET);
     }
 
-    private String doGenerateToken(Map<String, Object> claims, String subject) {
+    public String generateRefreshToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        Map<String, Object> headers = new HashMap<>();
+        headers.put("typ", "RefreshToken");
+        return doGenerateToken(claims, headers, userDetails.getUsername(), REFRESH_TOKEN_VALIDITY, REFRESH_TOKEN_SECRET);
+    }
+
+    private String doGenerateToken(Map<String, Object> claims, Map<String, Object> headers, String subject, long validity, String secret) {
         return Jwts.builder()
+                .setHeader(headers)
                 .setClaims(claims)
                 .setSubject(subject)
                 .setIssuedAt(new Date(System.currentTimeMillis()))
-                .setExpiration(new Date(System.currentTimeMillis() + JWT_TOKEN_VALIDITY))
+                .setExpiration(new Date(System.currentTimeMillis() + validity))
                 .signWith(SignatureAlgorithm.HS512, secret)
                 .compact();
     }
 
-    public Boolean validateToken(String token, UserDetails userDetails) {
-        String username = getUsernameFromToken(token);
-        return (username.equals(userDetails.getUsername())) && !isTokenExpired(token);
+    public Boolean validateAccessToken(String token) {
+        return validateToken(token, ACCESS_TOKEN_SECRET);
+    }
+
+    public Boolean validateRefreshToken(String token) {
+        return validateToken(token, REFRESH_TOKEN_SECRET);
+    }
+
+    private Boolean validateToken(String token, String secret) {
+        try {
+            Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
+        } catch (SignatureException e) {
+            throw new SignatureException(null);
+        } catch (ExpiredJwtException e) {
+            return false;
+        } catch (JwtException e) {
+            throw new InvalidJwtException();
+        }
+        return true;
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
@@ -60,7 +60,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
-                .antMatchers("/login", "/join", "/overlap/**", "/verification/**",
+                .antMatchers("/", "/login", "/join", "/overlap/**", "/verification/**",
                         "/swagger-resources/**", "/swagger-ui/**", "/help/**").permitAll()
                 .anyRequest().authenticated()
                 .and()

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
@@ -20,6 +20,10 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.CorsUtils;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.List;
+
+import static org.springframework.web.cors.CorsConfiguration.ALL;
+
 @Configuration
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true)
@@ -75,10 +79,11 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("*");
+        config.setAllowedOriginPatterns(List.of(ALL));
+        config.setAllowedMethods(List.of(ALL));
+        config.setAllowedHeaders(List.of(ALL));
         config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         source.registerCorsConfiguration("/**", config);

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/WebSecurityConfig.java
@@ -61,7 +61,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                 .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                 .antMatchers("/", "/login", "/join", "/overlap/**", "/verification/**",
-                        "/swagger-resources/**", "/swagger-ui/**", "/help/**").permitAll()
+                        "/swagger-resources/**", "/swagger-ui/**", "/help/**", "/reissue").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .exceptionHandling().authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
@@ -30,12 +30,12 @@ import java.util.Optional;
 import static GraduationWorkSalesProject.graduation.com.dto.result.ResultCode.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 
-// TODO: 만료된 인증 코드 모두 제거하는 로직 -> 어느 메소드에 추가할 지 고민 필요
-//  Redis -> heroku or aws에서 연동하는 방법 찾기
+// TODO:
+//  1. 만료된 인증 코드 모두 제거하는 로직 -> 회원가입, ID/PW 찾기 메소드에 동적 쿼리 추가 필요
+//  2. Redis -> heroku or aws에서 연동하는 방법 찾기
 
 @Api(tags = "회원 API")
 @Slf4j
-@CrossOrigin
 @RestController
 @RequiredArgsConstructor
 public class MemberController {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
@@ -48,8 +48,8 @@ public class MemberController {
     private final CertificateService certificateService;
 
     @ApiOperation(value = "로그인", notes = "로그인 성공 시, JWT 토큰을 Response Header(Authorization)에 넣어서 반환합니다")
-    @PostMapping(value = "/login", consumes = APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<ResultResponse> login(@Validated @ModelAttribute MemberLoginRequest request) {
+    @PostMapping(value = "/login", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResultResponse> login(@Validated @RequestBody MemberLoginRequest request) {
         memberService.checkUseridPassword(request.getUserid(), request.getPassword());
         UserDetails userDetails = userDetailsService.loadUserByUsername(request.getUserid());
         String token = jwtTokenUtil.generateToken(userDetails);
@@ -132,8 +132,8 @@ public class MemberController {
     }
 
     @ApiOperation(value = "회원가입")
-    @PostMapping(value = "/join", consumes = APPLICATION_FORM_URLENCODED_VALUE)
-    public ResponseEntity<ResultResponse> join(@Validated @ModelAttribute MemberJoinRequest request) throws ParseException {
+    @PostMapping(value = "/join", consumes = APPLICATION_JSON_VALUE)
+    public ResponseEntity<ResultResponse> join(@Validated @RequestBody MemberJoinRequest request) throws ParseException {
         validateCertificate(request);
 
         memberService.save(request);

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
@@ -8,9 +8,14 @@ import lombok.Getter;
 public enum ErrorCode {
 
     // Common
+    INTERNAL_SERVER_ERROR(500, "C000", "내부 서버 오류입니다."),
     ARGUMENT_INPUT_INVALID(400, "C001", "유효하지 않은 입력입니다."),
-    UNAUTHORIZED(401, "C002", "인증되지 않은 사용자입니다."),
-    INTERNAL_SERVER_ERROR(500, "C002", "내부 서버 오류입니다."),
+    EXPIRED_ACCESS_TOKEN(401, "C002", "만료된 Access Token입니다."),
+    EXPIRED_REFRESH_TOKEN(401, "C003", "만료된 Refresh Token입니다."),
+    INVALID_TOKEN(401, "C004", "유효하지 않은 토큰입니다."),
+    INVALID_AUTHORIZATION_HEADER(400, "C005", "유효하지 않은 인증 헤더입니다."),
+    REFRESH_TOKEN_NOT_MATCH(400, "C006", "Refresh Token이 일치하지 않습니다."),
+    SIGNATURE_NOT_MATCH(400, "C006", "JWT의 Signature이 일치하지 않습니다."),
 
     // Member
     LOGIN_INPUT_INVALID(400, "M001", "아이디 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberJoinRequest.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberJoinRequest.java
@@ -1,58 +1,61 @@
 package GraduationWorkSalesProject.graduation.com.dto.member;
 
 import GraduationWorkSalesProject.graduation.com.entity.member.Member;
-import io.swagger.annotations.ApiParam;
-import lombok.AllArgsConstructor;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
+@ApiModel(description = "회원 가입 데이터 모델")
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberJoinRequest {
 
-    @ApiParam(value = "아이디", example = "example123", required = true)
+    @ApiModelProperty(value = "아이디", example = "example123", required = true)
     @Pattern(regexp = "^[a-z0-9+]{5,20}$", message = "아이디는 5~20자의 영소문자, 숫자만 사용 가능합니다.")
     @NotEmpty(message = "아이디를 입력해주세요.")
     private String userid;
 
-    @ApiParam(value = "이메일", example = "example@gmail.com", required = true)
+    @ApiModelProperty(value = "이메일", example = "example@gmail.com", required = true)
     @Email(message = "이메일 형식이 잘못되었습니다.")
     @NotEmpty(message = "이메일을 입력해주세요.")
     private String email;
 
-    @ApiParam(value = "비밀번호(숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하)", example = "a1B2C!d#4ss", required = true)
+    @ApiModelProperty(value = "비밀번호(숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하)", example = "a1B2C!d#4ss", required = true)
     @Pattern(regexp = "^.*(?=^.{8,15}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$",
             message = "비밀번호는 숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하로 입력해주세요.")
     @NotEmpty(message = "비밀번호를 입력해주세요.")
     private String password;
 
-    @ApiParam(value = "닉네임", example = "만두", required = true)
+    @ApiModelProperty(value = "닉네임", example = "만두", required = true)
     @Length(min = 2, max = 10, message = "닉네임은 2자리 이상, 10자리 이하로 입력해주세요.")
     @NotEmpty(message = "닉네임을 입력해주세요.")
     private String username;
 
-    @ApiParam(value = "휴대폰번호", example = "010-1234-5678", required = true)
+    @ApiModelProperty(value = "휴대폰번호", example = "010-1234-5678", required = true)
     @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "휴대폰 번호는 010-1234-5678 형태로 입력해주세요.")
     @NotEmpty(message = "휴대폰 번호를 입력해주세요.")
     private String phoneNumber;
 
-    @ApiParam(value = "주소", example = "경기 성남시 분당구 판교역로 235", required = true)
+    @ApiModelProperty(value = "주소", example = "경기 성남시 분당구 판교역로 235", required = true)
     @NotEmpty(message = "주소를 입력해주세요.")
     private String address;
 
-    @ApiParam(value = "상세주소", example = "에이치스퀘어 N동 7층", required = true)
+    @ApiModelProperty(value = "상세주소", example = "에이치스퀘어 N동 7층", required = true)
     @NotEmpty(message = "상세주소를 입력해주세요.")
     private String detailAddress;
 
-    @ApiParam(value = "우편번호", example = "30872", required = true)
+    @ApiModelProperty(value = "우편번호", example = "30872", required = true)
     @NotEmpty(message = "우편번호를 입력해주세요.")
     private String postcode;
 
-    @ApiParam(value = "인증 토큰(hidden)", example = "wjRMbgPxtlKklzV2", required = true)
+    @ApiModelProperty(value = "인증 토큰(hidden)", example = "wjRMbgPxtlKklzV2", required = true)
     @Length(min = 16, max = 16, message = "인증 토큰은 16자리입니다.")
     @NotEmpty(message = "인증 토큰은 필수입니다.")
     private String token;

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberJwtTokenRequest.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberJwtTokenRequest.java
@@ -1,0 +1,23 @@
+package GraduationWorkSalesProject.graduation.com.dto.member;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotEmpty;
+
+@ApiModel(description = "JWT 토큰 재발급 데이터 모델")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberJwtTokenRequest {
+
+    @ApiModelProperty(value = "Access Token", example = "AAA.BBB.CCC", required = true)
+    @NotEmpty(message = "Access Token을 입력해주세요.")
+    private String accessToken;
+
+    @ApiModelProperty(value = "Refresh Token", example = "XXX.YYY.ZZZ", required = true)
+    @NotEmpty(message = "Refresh Token을 입력해주세요.")
+    private String refreshToken;
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberLoginRequest.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/member/MemberLoginRequest.java
@@ -1,21 +1,23 @@
 package GraduationWorkSalesProject.graduation.com.dto.member;
 
-import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.*;
 
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Pattern;
 
+@ApiModel(description = "회원 로그인 데이터 모델")
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberLoginRequest {
 
-    @ApiParam(value = "아이디", example = "example123", required = true)
+    @ApiModelProperty(value = "아이디", example = "example123", required = true)
     @Pattern(regexp = "^[a-z0-9+]{5,20}$", message = "아이디는 5~20자의 영소문자, 숫자만 사용 가능합니다.")
     @NotEmpty(message = "아이디를 입력해주세요.")
     private String userid;
 
-    @ApiParam(value = "비밀번호(숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하)", example = "a1B2C!d#4ss", required = true)
+    @ApiModelProperty(value = "비밀번호(숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하)", example = "a1B2C!d#4ss", required = true)
     @Pattern(regexp = "^.*(?=^.{8,15}$)(?=.*\\d)(?=.*[a-zA-Z])(?=.*[!@#$%^&+=]).*$",
             message = "비밀번호는 숫자, 문자, 특수문자를 포함한 8자리 이상, 15자리 이하로 입력해주세요.")
     @NotEmpty(message = "비밀번호를 입력해주세요.")

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/result/ResultCode.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/result/ResultCode.java
@@ -7,6 +7,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ResultCode {
 
+    // Common
+    REISSUE_SUCCESS(200,"C100", "Access Token 재발급 성공"),
+
     // Member
     LOGIN_SUCCESS(200, "M100", "로그인에 성공하였습니다."),
     EMAIL_VALID(200, "M101", "사용 가능한 이메일입니다."),

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/seller/SellerResponse.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/seller/SellerResponse.java
@@ -1,6 +1,7 @@
 package GraduationWorkSalesProject.graduation.com.dto.seller;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 @AllArgsConstructor
 @Getter

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/entity/certify/Certificate.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/entity/certify/Certificate.java
@@ -1,19 +1,30 @@
-package GraduationWorkSalesProject.graduation.com.redis;
+package GraduationWorkSalesProject.graduation.com.entity.certify;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import org.springframework.data.annotation.Id;
+import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Random;
 
+@Entity
 @Getter
-@RedisHash(value = "certificate", timeToLive = 30 * 60)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@RedisHash(value = "certificate", timeToLive = 30 * 60)
+@Table(name = "certificates")
 public class Certificate {
 
+//    @Id
     @Id
+    @Column(name = "certificate_token")
     private String token;
+    @Column(name = "certificate_expiration_date")
     private String expirationDateTime;
 
     public Certificate(String token, String expirationDateTime) {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/entity/certify/Certification.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/entity/certify/Certification.java
@@ -1,20 +1,34 @@
-package GraduationWorkSalesProject.graduation.com.redis;
+package GraduationWorkSalesProject.graduation.com.entity.certify;
 
+import lombok.AccessLevel;
 import lombok.Getter;
-import org.springframework.data.annotation.Id;
+import lombok.NoArgsConstructor;
 import org.springframework.data.redis.core.RedisHash;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.concurrent.ThreadLocalRandom;
 
+@Entity
 @Getter
-@RedisHash(value = "certification", timeToLive = 3 * 60)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@RedisHash(value = "certification", timeToLive = 3 * 60)
+@Table(name = "certifications")
 public class Certification {
 
+//    @Id
     @Id
+    @Column(name = "certificate_token")
     private String token;
+    @Column(name = "certificate_code")
     private String certificationCode;
+    @Column(name = "certificate_expiration_date")
     private String expirationDateTime;
 
     private Certification(String certificationCode, String expirationDateTime, String token) {
@@ -26,7 +40,7 @@ public class Certification {
     public static Certification create(String token){
         return new Certification(
                 Integer.toString(ThreadLocalRandom.current().nextInt(100000, 1000000)),
-                LocalDateTime.now().plusMinutes(3).format(DateTimeFormatter.ofPattern("yyyy.MM.dd. HH:mm:ss")),
+                ZonedDateTime.now(ZoneId.of("Asia/Seoul")).plusMinutes(3).format(DateTimeFormatter.ofPattern("yyyy.MM.dd. HH:mm:ss")),
                 token);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/entity/member/Member.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/entity/member/Member.java
@@ -67,6 +67,9 @@ public class Member {
     })
     private Image image;
 
+    @Column(name = "member_refresh_token")
+    private String refreshToken = null;
+
     @Builder
     public Member(String userid, String email, String password, String username, String phoneNumber,
                   String address, String detailAddress, String postcode) {
@@ -87,5 +90,9 @@ public class Member {
 
     public void encryptPassword(String encryptedPassword) {
         this.password = encryptedPassword;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredRefreshTokenException.java
@@ -1,0 +1,7 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+public class ExpiredRefreshTokenException extends RuntimeException {
+    public ExpiredRefreshTokenException() {
+        super();
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidAuthorizationHeaderException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidAuthorizationHeaderException.java
@@ -1,0 +1,7 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+public class InvalidAuthorizationHeaderException extends RuntimeException {
+    public InvalidAuthorizationHeaderException() {
+        super();
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidJwtException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidJwtException.java
@@ -1,0 +1,7 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+public class InvalidJwtException extends RuntimeException {
+    public InvalidJwtException() {
+        super();
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/RefreshTokenNotMatchException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/RefreshTokenNotMatchException.java
@@ -1,0 +1,7 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+public class RefreshTokenNotMatchException extends RuntimeException {
+    public RefreshTokenNotMatchException() {
+        super();
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificateRedisRepository.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificateRedisRepository.java
@@ -1,6 +1,6 @@
 package GraduationWorkSalesProject.graduation.com.repository;
 
-import GraduationWorkSalesProject.graduation.com.redis.Certificate;
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certificate;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CertificateRedisRepository extends CrudRepository<Certificate, String> {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificateRepository.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificateRepository.java
@@ -1,0 +1,8 @@
+package GraduationWorkSalesProject.graduation.com.repository;
+
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certificate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CertificateRepository extends JpaRepository<Certificate, String> {
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificationRedisRepository.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificationRedisRepository.java
@@ -1,6 +1,6 @@
 package GraduationWorkSalesProject.graduation.com.repository;
 
-import GraduationWorkSalesProject.graduation.com.redis.Certification;
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certification;
 import org.springframework.data.repository.CrudRepository;
 
 public interface CertificationRedisRepository extends CrudRepository<Certification, String> {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificationRepository.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/repository/CertificationRepository.java
@@ -1,0 +1,8 @@
+package GraduationWorkSalesProject.graduation.com.repository;
+
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.CrudRepository;
+
+public interface CertificationRepository extends JpaRepository<Certification, String> {
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificateDbService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificateDbService.java
@@ -1,32 +1,32 @@
 package GraduationWorkSalesProject.graduation.com.service;
 
 import GraduationWorkSalesProject.graduation.com.entity.certify.Certificate;
-import GraduationWorkSalesProject.graduation.com.repository.CertificateRedisRepository;
 import GraduationWorkSalesProject.graduation.com.repository.CertificateRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+@Primary
 @Service
 @RequiredArgsConstructor
-public class CertificateRedisService implements CertificateService{
+public class CertificateDbService implements CertificateService{
 
-    private final CertificateRedisRepository certificateRepository;
+    private final CertificateRepository certificateRepository;
 
+    @Override
     public void save(Certificate certificate) {
         certificateRepository.save(certificate);
     }
 
-    @Cacheable(value = "certificate", key = "#token", cacheManager = "cacheManager")
+    @Override
     public Optional<Certificate> findOne(String token) {
         return certificateRepository.findById(token);
     }
 
-    @CacheEvict(value = "certificate", key = "#token")
-    public void delete(String token){
+    @Override
+    public void delete(String token) {
         certificateRepository.deleteById(token);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificateService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificateService.java
@@ -1,0 +1,11 @@
+package GraduationWorkSalesProject.graduation.com.service;
+
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certificate;
+
+import java.util.Optional;
+
+public interface CertificateService {
+    void save(Certificate certificate);
+    Optional<Certificate> findOne(String token);
+    void delete(String token);
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificationDbService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificationDbService.java
@@ -1,32 +1,32 @@
 package GraduationWorkSalesProject.graduation.com.service;
 
 import GraduationWorkSalesProject.graduation.com.entity.certify.Certification;
-import GraduationWorkSalesProject.graduation.com.repository.CertificationRedisRepository;
 import GraduationWorkSalesProject.graduation.com.repository.CertificationRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
+import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
+@Primary
 @Service
 @RequiredArgsConstructor
-public class CertificationRedisService implements CertificationService{
+public class CertificationDbService implements CertificationService{
 
-    private final CertificationRedisRepository certificationRepository;
+    private final CertificationRepository certificationRepository;
 
+    @Override
     public void save(Certification certification) {
         certificationRepository.save(certification);
     }
 
-    @Cacheable(value = "certification", key = "#token", cacheManager = "cacheManager")
+    @Override
     public Optional<Certification> findOne(String token) {
         return certificationRepository.findById(token);
     }
 
-    @CacheEvict(value = "certification", key = "#token")
-    public void delete(String token){
+    @Override
+    public void delete(String token) {
         certificationRepository.deleteById(token);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificationService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/CertificationService.java
@@ -1,0 +1,11 @@
+package GraduationWorkSalesProject.graduation.com.service;
+
+import GraduationWorkSalesProject.graduation.com.entity.certify.Certification;
+
+import java.util.Optional;
+
+public interface CertificationService {
+    void save(Certification certification);
+    Optional<Certification> findOne(String token);
+    void delete(String token);
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/JwtUserDetailsService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/JwtUserDetailsService.java
@@ -23,17 +23,17 @@ public class JwtUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String userid) throws UsernameNotFoundException {
-        Optional<Member> findMember = memberRepository.findByUserid(userid);
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<Member> findMember = memberRepository.findByUsername(username);
 
         if (findMember.isPresent()) {
             List<GrantedAuthority> authorities = new ArrayList<>();
             authorities.add((GrantedAuthority) () -> findMember.get().getRole().name());
-            return new User(findMember.get().getUserid(),
+            return new User(findMember.get().getUsername(),
                     findMember.get().getPassword(),
                     new ArrayList<>(authorities));
         } else {
-            throw new UsernameNotFoundException("User not found with userid: " + userid);
+            throw new UsernameNotFoundException("User not found with username: " + username);
         }
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
@@ -1,13 +1,16 @@
 package GraduationWorkSalesProject.graduation.com.service;
 
+import GraduationWorkSalesProject.graduation.com.config.JwtTokenUtil;
 import GraduationWorkSalesProject.graduation.com.dto.member.MemberHelpFindPasswordRequest;
 import GraduationWorkSalesProject.graduation.com.dto.member.MemberJoinRequest;
+import GraduationWorkSalesProject.graduation.com.dto.member.MemberLoginRequest;
 import GraduationWorkSalesProject.graduation.com.entity.member.Member;
 import GraduationWorkSalesProject.graduation.com.exception.JoinInvalidInputException;
 import GraduationWorkSalesProject.graduation.com.exception.LoginInvalidInputException;
 import GraduationWorkSalesProject.graduation.com.exception.PasswordNotMatchException;
 import GraduationWorkSalesProject.graduation.com.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +24,7 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+    private final JwtTokenUtil jwtTokenUtil;
 
     @Transactional
     public void save(MemberJoinRequest memberJoinRequest) {
@@ -77,5 +81,15 @@ public class MemberService {
     @Transactional
     public void removeOneByUsername(String username) {
         memberRepository.deleteByUsername(username);
+    }
+
+    @Transactional
+    public String updateRefreshToken(MemberLoginRequest request, UserDetails userDetails) {
+        Member member = memberRepository.findByUserid(request.getUserid()).get();
+        if (member.getRefreshToken() == null || !jwtTokenUtil.validateRefreshToken(member.getRefreshToken())) {
+            String refreshToken = jwtTokenUtil.generateRefreshToken(userDetails);
+            member.updateRefreshToken(refreshToken);
+        }
+        return member.getRefreshToken();
     }
 }


### PR DESCRIPTION
- [x] DB를 이용한 인증코드 검증 로직 추가
- [x] Redis와 DB를 이용한 인증 관련 Service 구현체를 분리, interface를 생성하여 다형성 활용
- [x] 인증 관련 DB 테이블 추가
- [x] JWT 재발급 api 추가(Refresh Token 방식)

> Heroku or Aws에서 Redis 연동 방법 찾으면 Redis로 전환할 예정

Resolves: #10, #15