### PR TITLE
비즈니스 예외 핸들러 통합, 표준 예외 핸들러 추가

### DIFF
--- a/src/main/java/GraduationWorkSalesProject/graduation/com/advice/GlobalExceptionHandler.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/advice/GlobalExceptionHandler.java
@@ -1,100 +1,59 @@
 package GraduationWorkSalesProject.graduation.com.advice;
 
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
 import GraduationWorkSalesProject.graduation.com.dto.error.ErrorResponse;
 import GraduationWorkSalesProject.graduation.com.exception.*;
-import io.jsonwebtoken.SignatureException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import static GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode.*;
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
-import static org.springframework.http.HttpStatus.UNAUTHORIZED;
 
 @RestControllerAdvice("GraduationWorkSalesProject.graduation.com.controller")
 public class GlobalExceptionHandler {
 
-    // TODO: Exception 상속화하여 Business Exception Handler 하나로 통합
-    //  github 참고해서 설계해보기
-
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidExceptionHandler(BindException e) {
-        ErrorResponse response = ErrorResponse.of(ARGUMENT_INPUT_INVALID, e.getBindingResult());
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
         return new ResponseEntity<>(response, BAD_REQUEST);
     }
 
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> loginInputNotValidExceptionHandler(LoginInvalidInputException e) {
-        ErrorResponse response = ErrorResponse.of(LOGIN_INPUT_INVALID);
+    protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE, e.getBindingResult());
         return new ResponseEntity<>(response, BAD_REQUEST);
     }
 
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> joinInputDuplicationExceptionHandler(JoinInvalidInputException e) {
-        ErrorResponse response = ErrorResponse.of(JOIN_INPUT_DUPLICATION);
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        final ErrorResponse response = ErrorResponse.of(e);
         return new ResponseEntity<>(response, BAD_REQUEST);
     }
 
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> passwordNotMatchExceptionHandler(PasswordNotMatchException e) {
-        ErrorResponse response = ErrorResponse.of(PASSWORD_NOT_MATCH);
+    protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        final ErrorResponse response = ErrorResponse.of(INVALID_INPUT_VALUE);
         return new ResponseEntity<>(response, BAD_REQUEST);
     }
 
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> certificationCodeNotMatchExceptionHandler(CertificationCodeNotMatchException e) {
-        final ErrorResponse response = ErrorResponse.of(CERTIFICATION_CODE_NOT_MATCH);
-        return new ResponseEntity<>(response, BAD_REQUEST);
+    protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+        final ErrorResponse response = ErrorResponse.of(METHOD_NOT_ALLOWED);
+        return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> invalidCertificateExceptionHandler(InvalidCertificateException e) {
-        final ErrorResponse response = ErrorResponse.of(INVALID_CERTIFICATE);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> emailNotExistExceptionHandler(EmailNotExistException e) {
-        final ErrorResponse response = ErrorResponse.of(EMAIL_NOT_EXIST);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> useridNotExistExceptionHandler(UseridNotExistException e) {
-        final ErrorResponse response = ErrorResponse.of(USERID_NOT_EXIST);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> expiredRefreshTokenExceptionHandler(ExpiredRefreshTokenException e) {
-        final ErrorResponse response = ErrorResponse.of(EXPIRED_REFRESH_TOKEN);
-        return new ResponseEntity<>(response, UNAUTHORIZED);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> expiredCertificationCodeExceptionHandler(ExpiredCertificationCodeException e) {
-        final ErrorResponse response = ErrorResponse.of(EXPIRED_CERTIFICATION_CODE);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> refreshTokenNotMatchExceptionHandler(RefreshTokenNotMatchException e) {
-        final ErrorResponse response = ErrorResponse.of(REFRESH_TOKEN_NOT_MATCH);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> signatureExceptionHandler(SignatureException e) {
-        final ErrorResponse response = ErrorResponse.of(SIGNATURE_NOT_MATCH);
-        return new ResponseEntity<>(response, BAD_REQUEST);
-    }
-
-    @ExceptionHandler
-    protected ResponseEntity<ErrorResponse> invalidJwtExceptionHandler(InvalidJwtException e) {
-        final ErrorResponse response = ErrorResponse.of(INVALID_TOKEN);
-        return new ResponseEntity<>(response, UNAUTHORIZED);
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse response = ErrorResponse.of(errorCode);
+        return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
     }
 
     @ExceptionHandler

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
@@ -9,13 +9,15 @@ public enum ErrorCode {
 
     // Common
     INTERNAL_SERVER_ERROR(500, "C000", "내부 서버 오류입니다."),
-    ARGUMENT_INPUT_INVALID(400, "C001", "유효하지 않은 입력입니다."),
+    INVALID_INPUT_VALUE(400, "C001", "유효하지 않은 입력입니다."),
     EXPIRED_ACCESS_TOKEN(401, "C002", "만료된 Access Token입니다."),
     EXPIRED_REFRESH_TOKEN(401, "C003", "만료된 Refresh Token입니다."),
     INVALID_TOKEN(401, "C004", "유효하지 않은 토큰입니다."),
     INVALID_AUTHORIZATION_HEADER(400, "C005", "유효하지 않은 인증 헤더입니다."),
     REFRESH_TOKEN_NOT_MATCH(400, "C006", "Refresh Token이 일치하지 않습니다."),
     SIGNATURE_NOT_MATCH(400, "C006", "JWT의 Signature이 일치하지 않습니다."),
+    METHOD_NOT_ALLOWED(405, "C007", "허용되지 않은 HTTP method입니다."),
+    INVALID_TYPE_VALUE(400, "C008", "입력 타입이 유효하지 않습니다."),
 
     // Member
     LOGIN_INPUT_INVALID(400, "M001", "아이디 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorResponse.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorResponse.java
@@ -2,6 +2,7 @@ package GraduationWorkSalesProject.graduation.com.dto.error;
 
 import lombok.Getter;
 import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,12 @@ public class ErrorResponse {
 
     public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
         return new ErrorResponse(code, errors);
+    }
+
+    public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+        final String value = e.getValue() == null ? "" : e.getValue().toString();
+        final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+        return new ErrorResponse(ErrorCode.INVALID_TYPE_VALUE, errors);
     }
 
     @Getter

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/BusinessException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/BusinessException.java
@@ -1,0 +1,22 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class BusinessException extends RuntimeException {
+    private ErrorCode errorCode;
+
+    public BusinessException(String message, ErrorCode errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/CertificationCodeNotMatchException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/CertificationCodeNotMatchException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class CertificationCodeNotMatchException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class CertificationCodeNotMatchException extends BusinessException {
     public CertificationCodeNotMatchException() {
-        super();
+        super(ErrorCode.CERTIFICATION_CODE_NOT_MATCH);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotExistException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotExistException.java
@@ -1,8 +1,7 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class EmailNotExistException extends RuntimeException {
-    public EmailNotExistException() {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
 
-
-    }
+public class EmailNotExistException extends BusinessException {
+    public EmailNotExistException() { super(ErrorCode.EMAIL_NOT_EXIST); }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredCertificationCodeException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredCertificationCodeException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class ExpiredCertificationCodeException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class ExpiredCertificationCodeException extends BusinessException {
     public ExpiredCertificationCodeException() {
-        super();
+        super(ErrorCode.EXPIRED_CERTIFICATION_CODE);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredRefreshTokenException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/ExpiredRefreshTokenException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class ExpiredRefreshTokenException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class ExpiredRefreshTokenException extends BusinessException {
     public ExpiredRefreshTokenException() {
-        super();
+        super(ErrorCode.EXPIRED_REFRESH_TOKEN);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidAuthorizationHeaderException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidAuthorizationHeaderException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class InvalidAuthorizationHeaderException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class InvalidAuthorizationHeaderException extends BusinessException {
     public InvalidAuthorizationHeaderException() {
-        super();
+        super(ErrorCode.INVALID_AUTHORIZATION_HEADER);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidCertificateException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidCertificateException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class InvalidCertificateException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class InvalidCertificateException extends BusinessException {
     public InvalidCertificateException() {
-        super();
+        super(ErrorCode.INVALID_CERTIFICATE);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidJwtException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidJwtException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class InvalidJwtException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class InvalidJwtException extends BusinessException {
     public InvalidJwtException() {
-        super();
+        super(ErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/JoinInvalidInputException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/JoinInvalidInputException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class JoinInvalidInputException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class JoinInvalidInputException extends BusinessException {
     public JoinInvalidInputException() {
-        super();
+        super(ErrorCode.JOIN_INPUT_DUPLICATION);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/LoginInvalidInputException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/LoginInvalidInputException.java
@@ -1,6 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class LoginInvalidInputException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class LoginInvalidInputException extends BusinessException {
     public LoginInvalidInputException() {
+        super(ErrorCode.LOGIN_INPUT_INVALID);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/PasswordNotMatchException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/PasswordNotMatchException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class PasswordNotMatchException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class PasswordNotMatchException extends BusinessException {
     public PasswordNotMatchException() {
-        super();
+        super(ErrorCode.PASSWORD_NOT_MATCH);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/RefreshTokenNotMatchException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/RefreshTokenNotMatchException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class RefreshTokenNotMatchException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class RefreshTokenNotMatchException extends BusinessException {
     public RefreshTokenNotMatchException() {
-        super();
+        super(ErrorCode.REFRESH_TOKEN_NOT_MATCH);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotExistException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotExistException.java
@@ -1,7 +1,9 @@
 package GraduationWorkSalesProject.graduation.com.exception;
 
-public class UseridNotExistException extends RuntimeException {
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class UseridNotExistException extends BusinessException {
     public UseridNotExistException() {
-        super();
+        super(ErrorCode.USERID_NOT_EXIST);
     }
 }


### PR DESCRIPTION
## 변경 사항
### 비즈니스 예외 핸들러 통합 (#18)
- BusinessException을 추가하고, 각 커스텀 예외마다 BusinessException을 상속
- Advice에서 각 커스텀 예외마다 만들어 두었던 ExecptionHandler를 하나로 통일(`handleBusinessException`)
- 이후로, 커스텀 예외 추가 시, 개별적으로 ExceptionHandler 추가 불필요
### 표준 예외 핸들러 추가 (#19)
- 각 종 표준 예외에 대한 ExceptionHandler 추가 -> #19 참고!