### PR TITLE
Fix: 회원 API 에러

### DIFF
--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/Scheduler.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/Scheduler.java
@@ -25,7 +25,7 @@ public class Scheduler {
     public void clearExpiredTokens(){
         log.info("clear expired tokens!");
         final LocalDateTime before3Minutes = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(3L).toLocalDateTime();
-        final LocalDateTime before30Minutes = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(3L).toLocalDateTime();
+        final LocalDateTime before30Minutes = ZonedDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(30L).toLocalDateTime();
 
         certificationRepository.deleteByExpirationDateTimeLessThan(before3Minutes);
         certificateRepository.deleteByExpirationDateTimeLessThan(before30Minutes);

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
@@ -84,7 +84,6 @@ public class MemberService {
     public String updateRefreshToken(MemberLoginRequest request) {
         final Member member = memberRepository.findByUserid(request.getUserid()).orElseThrow(UseridNotExistException::new);
         if (member.getRefreshToken() == null) {
-            jwtTokenUtil.validateRefreshToken(member.getRefreshToken());
             final UserDetails userDetails = userDetailsService.loadUserByUsername(member.getUsername());
             final String refreshToken = jwtTokenUtil.generateRefreshToken(userDetails);
             member.updateRefreshToken(refreshToken);


### PR DESCRIPTION
## 문제점
- 회원 가입 시, refresh_token을 null로 초기화해주는데, 로그인 시에 이 토큰을 가져와서 검증하는 로직이 추가되어 있었음.
- 해당 로직 제거 후, 해당 에러가 더 이상 발생하지 않음.
## 수정 사항
- MemberService의 `updateRefreshToken` 메소드에서 `validateRefreshToken` 메소드 호출 제거
- 스케줄러에서 인증서 삭제 시간 오타 수정

Resolve: #29