### PR TITLE
Fix: JWT 재발급 API

### DIFF
--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
@@ -83,15 +83,13 @@ public class JwtTokenUtil {
     }
 
     public void validateRefreshToken(String token) {
-        if (validateToken(token, REFRESH_TOKEN_SECRET))
+        if (!validateToken(token, REFRESH_TOKEN_SECRET))
             throw new ExpiredRefreshTokenException();
     }
 
     private Boolean validateToken(String token, String secret) {
         try {
             Jwts.parser().setSigningKey(secret).parseClaimsJws(token).getBody();
-        } catch (SignatureException e) {
-            throw new SignatureException(null);
         } catch (ExpiredJwtException e) {
             return false;
         } catch (JwtException e) {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
@@ -108,13 +108,12 @@ public class MemberService {
 
     public String getUsernameFromRefreshJwt(String refreshToken) {
         final String username = jwtTokenUtil.getUsernameFromRefreshToken(refreshToken);
-        checkRefreshToken(refreshToken);
+        checkRefreshToken(refreshToken, username);
 
         return username;
     }
 
-    private void checkRefreshToken(String refreshToken){
-        final String username = getUsernameFromRefreshJwt(refreshToken);
+    private void checkRefreshToken(String refreshToken, String username){
         final Member member = memberRepository.findByUsername(username).orElseThrow(UseridNotExistException::new);
         if (!member.getRefreshToken().equals(refreshToken))
             throw new RefreshTokenNotMatchException();


### PR DESCRIPTION
[JwtTokenUtil]
- validateRefreshToken 메소드 수정
  - validateToken 결과가 false일 때, 예외 발생하도록 수정
- validateToken 메소드 수정
  - SignatureException보다 JwtException이 상위 개념이므로 통합

[MemberService]
- checkRefreshToken 메소드 수정
  - 순환 호출 코드 삭제

Resolve: #31