### PR TITLE
Refactor: JWT 예외 클래스명 변경

### DIFF
--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtRequestFilter.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtRequestFilter.java
@@ -61,7 +61,7 @@ public class JwtRequestFilter extends OncePerRequestFilter {
             request.setAttribute("errorCode", EXPIRED_ACCESS_TOKEN);
         } catch (JwtException e) {
             log.warn("Unable to get JWT Token");
-            request.setAttribute("errorCode", INVALID_TOKEN);
+            request.setAttribute("errorCode", INVALID_JWT);
         }
 
         filterChain.doFilter(request, response);

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
@@ -12,12 +12,13 @@ public enum ErrorCode {
     INVALID_INPUT_VALUE(400, "C001", "유효하지 않은 입력입니다."),
     EXPIRED_ACCESS_TOKEN(401, "C002", "만료된 Access Token입니다."),
     EXPIRED_REFRESH_TOKEN(401, "C003", "만료된 Refresh Token입니다."),
-    INVALID_TOKEN(401, "C004", "유효하지 않은 토큰입니다."),
+    INVALID_JWT(401, "C004", "유효하지 않은 JWT입니다."),
     INVALID_AUTHORIZATION_HEADER(400, "C005", "유효하지 않은 인증 헤더입니다."),
     REFRESH_TOKEN_NOT_MATCH(400, "C006", "Refresh Token이 일치하지 않습니다."),
     SIGNATURE_NOT_MATCH(400, "C006", "JWT의 Signature이 일치하지 않습니다."),
     METHOD_NOT_ALLOWED(405, "C007", "허용되지 않은 HTTP method입니다."),
     INVALID_TYPE_VALUE(400, "C008", "입력 타입이 유효하지 않습니다."),
+    INVALID_TOKEN(400, "C009", "유효하지 않은 토큰입니다."),
 
     // Member
     LOGIN_INPUT_INVALID(400, "M001", "아이디 또는 비밀번호가 일치하지 않습니다."),

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidTokenException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/InvalidTokenException.java
@@ -2,8 +2,8 @@ package GraduationWorkSalesProject.graduation.com.exception;
 
 import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
 
-public class InvalidJwtException extends BusinessException {
-    public InvalidJwtException() {
-        super(ErrorCode.INVALID_JWT);
+public class InvalidTokenException extends BusinessException {
+    public InvalidTokenException() {
+        super(ErrorCode.INVALID_TOKEN);
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/certificate/CertificateDbService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/certificate/CertificateDbService.java
@@ -38,7 +38,7 @@ public class CertificateDbService implements CertificateService {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
         Optional<Certificate> findCertificate = certificateRepository.findById(token);
 
-        if (findCertificate.isEmpty() || !findCertificate.get().getToken().equals(token))
+        if (findCertificate.isEmpty())
             throw new InvalidCertificateException();
 
         LocalDateTime expirationDateTime = findCertificate.get().getExpirationDateTime();

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/certification/CertificationDbService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/certification/CertificationDbService.java
@@ -4,13 +4,13 @@ import GraduationWorkSalesProject.graduation.com.dto.member.MemberCertificationC
 import GraduationWorkSalesProject.graduation.com.entity.certify.Certification;
 import GraduationWorkSalesProject.graduation.com.exception.CertificationCodeNotMatchException;
 import GraduationWorkSalesProject.graduation.com.exception.ExpiredCertificationCodeException;
+import GraduationWorkSalesProject.graduation.com.exception.InvalidTokenException;
 import GraduationWorkSalesProject.graduation.com.repository.CertificationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.text.ParseException;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
@@ -38,7 +38,7 @@ public class CertificationDbService implements CertificationService{
     public void validateCertification(MemberCertificationCodeRequest request) {
         ZonedDateTime now = ZonedDateTime.now(ZoneId.of("Asia/Seoul"));
         Certification findCertification = certificationRepository.findById(request.getToken())
-                .orElseThrow(ExpiredCertificationCodeException::new);
+                .orElseThrow(InvalidTokenException::new);
 
         if (!findCertification.getCertificationCode().equals(request.getCertificationCode()))
             throw new CertificationCodeNotMatchException();


### PR DESCRIPTION
- InvalidTokenException, 에러 코드 추가
- JWT 예외와 Front단에서 넘겨주는 Token 예외를 구분해서 사용
- CertificationDbService에서 불필요한 중복 코드 제거

Resolve: #33