### PR TITLE
Refactor: 회원 API 리팩토링

### DIFF
--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/JwtTokenUtil.java
@@ -31,26 +31,13 @@ public class JwtTokenUtil {
         return getClaimFromAccessToken(token, Claims::getSubject);
     }
 
-    public String getUsernameFromRefreshToken(String token) {
-        return getClaimFromRefreshToken(token, Claims::getSubject);
-    }
-
     public <T> T getClaimFromAccessToken(String token, Function<Claims, T> claimsResolver) {
         Claims claims = getAllClaimsFromAccessToken(token);
         return claimsResolver.apply(claims);
     }
 
-    public <T> T getClaimFromRefreshToken(String token, Function<Claims, T> claimsResolver) {
-        Claims claims = getAllClaimsFromRefreshToken(token);
-        return claimsResolver.apply(claims);
-    }
-
     private Claims getAllClaimsFromAccessToken(String token) {
         return Jwts.parser().setSigningKey(ACCESS_TOKEN_SECRET).parseClaimsJws(token).getBody();
-    }
-
-    private Claims getAllClaimsFromRefreshToken(String token) {
-        return Jwts.parser().setSigningKey(REFRESH_TOKEN_SECRET).parseClaimsJws(token).getBody();
     }
 
     public String generateAccessToken(UserDetails userDetails) {

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/config/SwaggerConfig.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/config/SwaggerConfig.java
@@ -3,12 +3,17 @@ package GraduationWorkSalesProject.graduation.com.config;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.ApiInfo;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @EnableSwagger2
 @Configuration
@@ -16,7 +21,19 @@ public class SwaggerConfig {
 
     @Bean
     public Docket api() {
+        // Authorization header 글로벌 처리
+        List global = new ArrayList();
+        global.add(new ParameterBuilder()
+                .name("Authorization")
+                .description("Access Token")
+                .parameterType("header")
+                .required(true)
+                .modelRef(new ModelRef("string"))
+                .scalarExample("Bearer AAA.BBB.CCC")
+                .build());
+
         return new Docket(DocumentationType.SWAGGER_2)
+                .globalOperationParameters(global)
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())
                 .select()

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/controller/MemberController.java
@@ -1,6 +1,5 @@
 package GraduationWorkSalesProject.graduation.com.controller;
 
-import GraduationWorkSalesProject.graduation.com.config.JwtTokenUtil;
 import GraduationWorkSalesProject.graduation.com.dto.member.MemberJwtTokenRequest;
 import GraduationWorkSalesProject.graduation.com.dto.certification.CertificateResponse;
 import GraduationWorkSalesProject.graduation.com.dto.certification.CertificationCodeResponse;
@@ -20,6 +19,7 @@ import io.swagger.annotations.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
@@ -44,6 +44,7 @@ public class MemberController {
     private final CertificateService certificateService;
 
     @ApiOperation(value = "로그인", notes = "로그인 성공 시, JWT 토큰을 Response Header에 넣어서 반환합니다")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/login", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> login(@Validated @RequestBody MemberLoginRequest request) {
         memberService.checkUseridPassword(request.getUserid(), request.getPassword());
@@ -58,11 +59,12 @@ public class MemberController {
     }
 
     @ApiOperation(value = "JWT 토큰 재발급", notes = "재발급 성공 시, JWT 토큰을 Response Header에 넣어서 반환합니다")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/reissue", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> reIssueAccessToken(@Validated @RequestBody MemberJwtTokenRequest request) {
         memberService.validateJwts(request.getAccessToken(), request.getRefreshToken());
 
-        final String username = memberService.getUsernameFromRefreshJwt(request.getRefreshToken());
+        final String username = SecurityContextHolder.getContext().getAuthentication().getName();
         final String accessToken = memberService.createAccessTokenByUsername(username);
 
         return ResponseEntity.ok()
@@ -71,6 +73,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "이메일 인증 코드 발송")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/verification/email", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> sendCertificationCode(@Validated @RequestBody MemberEmailCertificationRequest request) {
         final String subject = "[그라듀] 이메일 인증코드 안내";
@@ -86,6 +89,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "인증 코드 검증")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/verification/code", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> verifyCertificationCode(@Validated @RequestBody MemberCertificationCodeRequest request) {
         certificationService.validateCertification(request);
@@ -101,6 +105,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "이메일 중복 체크")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/overlap/email", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> checkEmailExists(@Validated @RequestBody MemberEmailCheckRequest request) {
         final Optional<Member> findMember = memberService.findOneByEmail(request.getEmail());
@@ -110,6 +115,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "아이디 중복 체크")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/overlap/userid", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> checkUseridExists(@Validated @RequestBody MemberUseridCheckRequest request) {
         final Optional<Member> findMember = memberService.findOneByUserid(request.getUserid());
@@ -119,6 +125,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "닉네임 중복 체크")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/overlap/username", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> checkUsernameExists(@Validated @RequestBody MemberUsernameCheckRequest request) {
         final Optional<Member> findMember = memberService.findOneByUsername(request.getUsername());
@@ -128,6 +135,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "회원가입")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/join", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> join(@Validated @RequestBody MemberJoinRequest request) {
         certificateService.validateCertificate(request.getToken());
@@ -138,21 +146,21 @@ public class MemberController {
     }
 
     @ApiOperation(value = "회원탈퇴")
-    @ApiImplicitParam(name = "Authorization", value = "권한", example = "Bearer xxx.yyy.zzz")
     @DeleteMapping("/leave")
-    public ResponseEntity<ResultResponse> leave(@RequestHeader("Authorization") String authorization) {
-        final String username = memberService.getUsernameFromAccessJwt(authorization);
+    public ResponseEntity<ResultResponse> leave() {
+        final String username = SecurityContextHolder.getContext().getAuthentication().getName();
         memberService.removeOneByUsername(username);
 
         return ResponseEntity.ok(ResultResponse.of(LEAVE_SUCCESS, null));
     }
 
     @ApiOperation(value = "아이디 찾기")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/help/id", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> helpFindUserid(@Validated @RequestBody MemberHelpFindUseridRequest request) {
         certificateService.validateCertificate(request.getToken());
 
-        final Member member = memberService.findOneByEmail(request.getEmail()).orElseThrow(EmailNotExistException::new);
+        final Member member = memberService.findOneByEmail(request.getEmail()).orElseThrow(EmailNotFoundException::new);
         final MemberFindUseridResponse response = new MemberFindUseridResponse(member.getUserid());
         certificateService.delete(request.getToken());
 
@@ -160,6 +168,7 @@ public class MemberController {
     }
 
     @ApiOperation(value = "비밀번호 찾기")
+    @ApiImplicitParam(name = "Authorization", value = "불필요", required = false, example = " ")
     @PostMapping(value = "/help/password", consumes = APPLICATION_JSON_VALUE)
     public ResponseEntity<ResultResponse> helpChangePassword(@Validated @RequestBody MemberHelpFindPasswordRequest request) {
         certificateService.validateCertificate(request.getToken());

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/dto/error/ErrorCode.java
@@ -26,9 +26,10 @@ public enum ErrorCode {
     PASSWORD_NOT_MATCH(400, "M003", "새 비밀번호와 비밀번호 확인이 일치하지 않습니다."),
     CERTIFICATION_CODE_NOT_MATCH(400, "M004", "잘못된 인증 코드입니다."),
     INVALID_CERTIFICATE(400, "M005", "유효하지 않은 인증서입니다."),
-    EMAIL_NOT_EXIST(400, "M006", "해당 이메일로 가입한 회원은 존재하지 않습니다"),
-    USERID_NOT_EXIST(400, "M007", "해당 아이디는 존재하지 않습니다"),
-    EXPIRED_CERTIFICATION_CODE(400, "M005", "만료된 인증 코드입니다."),
+    EMAIL_NOT_FOUND(400, "M006", "해당 이메일로 가입한 회원은 존재하지 않습니다"),
+    USERID_NOT_FOUND(400, "M007", "해당 아이디의 회원은 존재하지 않습니다"),
+    USERNAME_NOT_FOUND(400, "M008", "해당 닉네임의 회원은 존재하지 않습니다"),
+    EXPIRED_CERTIFICATION_CODE(400, "M009", "만료된 인증 코드입니다."),
     ;
 
     private int status;

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/entity/member/Member.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/entity/member/Member.java
@@ -33,7 +33,7 @@ public class Member {
     @Column(name = "member_userid", unique = true)
     private String userid;
 
-    @Column(name = "member_username")
+    @Column(name = "member_username", unique = true)
     private String username;
 
     @Column(name = "member_phone_number")

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotExistException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotExistException.java
@@ -1,7 +1,0 @@
-package GraduationWorkSalesProject.graduation.com.exception;
-
-import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
-
-public class EmailNotExistException extends BusinessException {
-    public EmailNotExistException() { super(ErrorCode.EMAIL_NOT_EXIST); }
-}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotFoundException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/EmailNotFoundException.java
@@ -1,0 +1,7 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class EmailNotFoundException extends BusinessException {
+    public EmailNotFoundException() { super(ErrorCode.EMAIL_NOT_FOUND); }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotExistException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotExistException.java
@@ -1,9 +1,0 @@
-package GraduationWorkSalesProject.graduation.com.exception;
-
-import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
-
-public class UseridNotExistException extends BusinessException {
-    public UseridNotExistException() {
-        super(ErrorCode.USERID_NOT_EXIST);
-    }
-}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotFoundException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UseridNotFoundException.java
@@ -1,0 +1,9 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class UseridNotFoundException extends BusinessException {
+    public UseridNotFoundException() {
+        super(ErrorCode.USERID_NOT_FOUND);
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UsernameNotFoundException.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/exception/UsernameNotFoundException.java
@@ -1,0 +1,10 @@
+package GraduationWorkSalesProject.graduation.com.exception;
+
+import GraduationWorkSalesProject.graduation.com.dto.error.ErrorCode;
+
+public class UsernameNotFoundException extends BusinessException{
+
+    public UsernameNotFoundException() {
+        super(ErrorCode.USERNAME_NOT_FOUND);
+    }
+}

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/JwtUserDetailsService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/JwtUserDetailsService.java
@@ -1,19 +1,18 @@
 package GraduationWorkSalesProject.graduation.com.service;
 
 import GraduationWorkSalesProject.graduation.com.entity.member.Member;
+import GraduationWorkSalesProject.graduation.com.exception.UsernameNotFoundException;
 import GraduationWorkSalesProject.graduation.com.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,17 +22,13 @@ public class JwtUserDetailsService implements UserDetailsService {
     private final MemberRepository memberRepository;
 
     @Override
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        Optional<Member> findMember = memberRepository.findByUsername(username);
+    public UserDetails loadUserByUsername(String username) {
+        Member findMember = memberRepository.findByUsername(username).orElseThrow(UsernameNotFoundException::new);
 
-        if (findMember.isPresent()) {
-            List<GrantedAuthority> authorities = new ArrayList<>();
-            authorities.add((GrantedAuthority) () -> findMember.get().getRole().name());
-            return new User(findMember.get().getUsername(),
-                    findMember.get().getPassword(),
-                    new ArrayList<>(authorities));
-        } else {
-            throw new UsernameNotFoundException("User not found with username: " + username);
-        }
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add((GrantedAuthority) () -> findMember.getRole().name());
+        return new User(findMember.getUsername(),
+                findMember.getPassword(),
+                new ArrayList<>(authorities));
     }
 }

--- a/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
+++ b/src/main/java/GraduationWorkSalesProject/graduation/com/service/MemberService.java
@@ -2,12 +2,12 @@ package GraduationWorkSalesProject.graduation.com.service;
 
 import GraduationWorkSalesProject.graduation.com.config.JwtTokenUtil;
 import GraduationWorkSalesProject.graduation.com.dto.member.MemberJoinRequest;
-import GraduationWorkSalesProject.graduation.com.dto.member.MemberJwtTokenRequest;
 import GraduationWorkSalesProject.graduation.com.dto.member.MemberLoginRequest;
 import GraduationWorkSalesProject.graduation.com.entity.member.Member;
 import GraduationWorkSalesProject.graduation.com.exception.*;
 import GraduationWorkSalesProject.graduation.com.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -48,7 +48,7 @@ public class MemberService {
 
     @Transactional
     public void changePassword(String userid, String newPassword, String checkPassword) {
-        Member findMember = memberRepository.findByUserid(userid).orElseThrow(UseridNotExistException::new);
+        Member findMember = memberRepository.findByUserid(userid).orElseThrow(UseridNotFoundException::new);
         if (!newPassword.equals(checkPassword))
             throw new PasswordNotMatchException();
 
@@ -82,17 +82,16 @@ public class MemberService {
 
     @Transactional
     public String updateRefreshToken(MemberLoginRequest request) {
-        final Member member = memberRepository.findByUserid(request.getUserid()).orElseThrow(UseridNotExistException::new);
-        if (member.getRefreshToken() == null) {
-            final UserDetails userDetails = userDetailsService.loadUserByUsername(member.getUsername());
-            final String refreshToken = jwtTokenUtil.generateRefreshToken(userDetails);
-            member.updateRefreshToken(refreshToken);
-        }
-        return member.getRefreshToken();
+        final Member member = memberRepository.findByUserid(request.getUserid()).orElseThrow(UseridNotFoundException::new);
+        final UserDetails userDetails = userDetailsService.loadUserByUsername(member.getUsername());
+        final String refreshToken = jwtTokenUtil.generateRefreshToken(userDetails);
+
+        member.updateRefreshToken(refreshToken);
+        return refreshToken;
     }
 
     public String createAccessTokenByUserid(String userid) {
-        final Member member = memberRepository.findByUserid(userid).orElseThrow(UseridNotExistException::new);
+        final Member member = memberRepository.findByUserid(userid).orElseThrow(UseridNotFoundException::new);
         final UserDetails userDetails = userDetailsService.loadUserByUsername(member.getUsername());
         return jwtTokenUtil.generateAccessToken(userDetails);
     }
@@ -102,19 +101,9 @@ public class MemberService {
         return jwtTokenUtil.generateAccessToken(userDetails);
     }
 
-    public String getUsernameFromAccessJwt(String accessToken) {
-        return jwtTokenUtil.getUsernameFromAccessToken(accessToken.substring(7));
-    }
-
-    public String getUsernameFromRefreshJwt(String refreshToken) {
-        final String username = jwtTokenUtil.getUsernameFromRefreshToken(refreshToken);
-        checkRefreshToken(refreshToken, username);
-
-        return username;
-    }
-
-    private void checkRefreshToken(String refreshToken, String username){
-        final Member member = memberRepository.findByUsername(username).orElseThrow(UseridNotExistException::new);
+    private void checkRefreshToken(String refreshToken){
+        final String username = SecurityContextHolder.getContext().getAuthentication().getName();
+        final Member member = memberRepository.findByUsername(username).orElseThrow(UseridNotFoundException::new);
         if (!member.getRefreshToken().equals(refreshToken))
             throw new RefreshTokenNotMatchException();
     }
@@ -122,5 +111,6 @@ public class MemberService {
     public void validateJwts(String accessToken, String refreshToken) {
         jwtTokenUtil.validateAccessToken(accessToken);
         jwtTokenUtil.validateRefreshToken(refreshToken);
+        checkRefreshToken(refreshToken);
     }
 }


### PR DESCRIPTION
### 변경 사항
- 회원 정보(username)를 JWT에서 가져오는 코드에서 Spring Security Context에서 가져오는 코드로 수정
    ```java
    final String username = SecurityContextHolder.getContext().getAuthentication().getName();
    // 이제 위 코드 이용해서 `username` 받아 사용하시면 됩니다!
    ```
- 예외 이름 중 "Exist" 단어 -> "Found"로 수정
    - UseridNotExistException -> UseridNotFoundException
    - EmailNotExistException -> EmailNotFoundException
- 불필요 메소드 제거(MemberService, JwtTokenUtil)
- 로그인 시, Refresh Token도 재발급하는 방식으로 수정
- Swagger 어노테이션 Authorization 헤더 글로벌 설정 추가
    > 이제 API마다 @ApiOperation으로 해당 헤더부분 추가하지 않아도 됩니다.

Resolve: #38